### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,5 @@
   },
   "keywords": [
     "npm"
-  ],
-  "license": "MIT"
+  ]
 }


### PR DESCRIPTION
Removing `license` field since we already defined `licenses` on L18.

Also, we should provide a `url` to the MIT license (I couldn't find a generic MIT license to point the URL to, so you may want to copy the MIT license into your repro and point the URL there). There is a template on http://en.wikipedia.org/wiki/MIT_License which you can copy/paste and enter the year and your name, or whatever. 
According to http://package-json-validator.com/ the package.json isn't 100% valid because:

```
{
  "valid": false,
  "errors": [
    "licenses field should have url"
  ],
  "warnings": [
    "Missing recommended field: contributors"
  ]
}
```
